### PR TITLE
Add redux worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "y",
+  "name": "redux-webworker",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1652,6 +1652,15 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1725,6 +1734,17 @@
       "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.7.tgz",
+      "integrity": "sha512-U+WrzeFfI83+evZE2dkZ/oF/1vjIYgqrb5dGgedkqVV8HEfDFujNgWCwHL89TDuWKb47U0nTBT6PLGq4IIogWg==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/stack-utils": {
@@ -5119,6 +5139,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hsl-regex": {
@@ -9454,6 +9482,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
       "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.0.tgz",
@@ -9497,6 +9537,15 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "reflect.ownkeys": {
@@ -10516,6 +10565,11 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "typescript-react-parcel-prettier-starter",
+    "name": "redux-webworker",
     "version": "1.0.0",
     "description": "",
     "main": "src/index.html",
@@ -17,10 +17,13 @@
         "@types/parcel-env": "0.0.0",
         "@types/react": "^16.9.23",
         "@types/react-dom": "^16.9.5",
+        "@types/react-redux": "^7.1.7",
         "parcel-bundler": "^1.12.4",
         "prettier": "^1.19.1",
         "react": "^16.13.0",
         "react-dom": "^16.13.0",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.5",
         "typescript": "^3.8.3"
     },
     "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { Provider } from 'react-redux'
+import store from './store'
+import Counter from './containers/Counter'
+
+const App = () => {
+    return (
+        <Provider store={store}>
+            <h1>Hello</h1>
+            <Counter />
+        </Provider>
+    )
+}
+
+export default App

--- a/src/actions/constants.ts
+++ b/src/actions/constants.ts
@@ -1,0 +1,2 @@
+export const INCREMENT = 'INCREMENT'
+export const DECREMENT = 'DECREMENT'

--- a/src/actions/constants.ts
+++ b/src/actions/constants.ts
@@ -1,2 +1,3 @@
 export const INCREMENT = 'INCREMENT'
 export const DECREMENT = 'DECREMENT'
+export const SET_COUNT = 'SET_COUNT'

--- a/src/actions/counter.ts
+++ b/src/actions/counter.ts
@@ -1,0 +1,23 @@
+import { INCREMENT, DECREMENT } from '~/actions/constants'
+
+type IncrementAction = {
+    type: typeof INCREMENT
+}
+
+type DecrementAction = {
+    type: typeof DECREMENT
+}
+
+export const increment = (): IncrementAction => ({
+    type: INCREMENT,
+})
+
+export const decrement = (): DecrementAction => ({
+    type: DECREMENT,
+})
+export type Action =
+    | IncrementAction
+    | DecrementAction
+    | {
+          type: unknown
+      }

--- a/src/actions/counter.ts
+++ b/src/actions/counter.ts
@@ -1,11 +1,16 @@
-import { INCREMENT, DECREMENT } from '~/actions/constants'
+import { INCREMENT, DECREMENT, SET_COUNT } from '~/actions/constants'
 
-type IncrementAction = {
+export type IncrementAction = {
     type: typeof INCREMENT
 }
 
-type DecrementAction = {
+export type DecrementAction = {
     type: typeof DECREMENT
+}
+
+export type SetCountAction = {
+    type: typeof SET_COUNT
+    payload: number
 }
 
 export const increment = (): IncrementAction => ({
@@ -15,9 +20,8 @@ export const increment = (): IncrementAction => ({
 export const decrement = (): DecrementAction => ({
     type: DECREMENT,
 })
-export type Action =
-    | IncrementAction
-    | DecrementAction
-    | {
-          type: unknown
-      }
+
+export const setCount = (payload: number) => ({
+    type: SET_COUNT,
+    payload,
+})

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,3 @@
+import { IncrementAction, DecrementAction, SetCountAction } from './counter'
+
+export type Action = IncrementAction | DecrementAction | SetCountAction | never

--- a/src/containers/Counter.tsx
+++ b/src/containers/Counter.tsx
@@ -5,16 +5,18 @@ import { increment, decrement, setCount } from '~/actions/counter'
 
 type Props = {
     count: number
+    doubleCount: number
     increment: () => void
     decrement: () => void
     setCount: (value: number) => void
 }
 
 const Counter = (props: Props) => {
-    const { increment, decrement, setCount, count } = props
+    const { increment, decrement, setCount, count, doubleCount } = props
     return (
         <div>
-            Current count is {count}
+            <p>Current count is {count}</p>
+            <p>Double count is {doubleCount}</p>
             <br></br>
             <button onClick={increment}>➕</button>
             <button onClick={decrement}>➖</button>
@@ -26,6 +28,7 @@ const Counter = (props: Props) => {
 const mapStateToProps = (state: State) => {
     return {
         count: state.count,
+        doubleCount: state.doubleCount,
     }
 }
 

--- a/src/containers/Counter.tsx
+++ b/src/containers/Counter.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { State } from '~/store'
+import { connect } from 'react-redux'
+import { increment, decrement } from '~/actions/counter'
+
+type Props = {
+    count: number
+    increment: () => void
+    decrement: () => void
+}
+
+const Counter = (props: Props) => {
+    const { increment, decrement, count } = props
+    return (
+        <div>
+            Current count is {count}
+            <br></br>
+            <button onClick={increment}>➕</button>
+            <button onClick={decrement}>➖</button>
+        </div>
+    )
+}
+
+const mapStateToProps = (state: State) => {
+    return {
+        count: state.count,
+    }
+}
+
+const mapDispatchToProps = {
+    increment,
+    decrement,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Counter)

--- a/src/containers/Counter.tsx
+++ b/src/containers/Counter.tsx
@@ -1,22 +1,24 @@
 import React from 'react'
 import { State } from '~/store'
 import { connect } from 'react-redux'
-import { increment, decrement } from '~/actions/counter'
+import { increment, decrement, setCount } from '~/actions/counter'
 
 type Props = {
     count: number
     increment: () => void
     decrement: () => void
+    setCount: (value: number) => void
 }
 
 const Counter = (props: Props) => {
-    const { increment, decrement, count } = props
+    const { increment, decrement, setCount, count } = props
     return (
         <div>
             Current count is {count}
             <br></br>
             <button onClick={increment}>➕</button>
             <button onClick={decrement}>➖</button>
+            <button onClick={() => setCount(0)}>❌</button>
         </div>
     )
 }
@@ -30,6 +32,7 @@ const mapStateToProps = (state: State) => {
 const mapDispatchToProps = {
     increment,
     decrement,
+    setCount,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Counter)

--- a/src/index.html
+++ b/src/index.html
@@ -9,4 +9,11 @@
         <div id="app"></div>
         <script src="index.tsx"></script>
     </body>
+
+    <style>
+        * {
+            font-family: Roboto;
+            font-size: 1.25rem;
+        }
+    </style>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import App from '~/App'
 
 const root = document.getElementById('app')
-
-const App = () => <h1>Hello</h1>
 
 ReactDOM.render(<App />, root)

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -3,6 +3,7 @@ import { INCREMENT, DECREMENT, SET_COUNT } from '~/actions/constants'
 
 export const initialState = {
     count: 0,
+    doubleCount: 0,
 }
 
 export type State = typeof initialState
@@ -13,18 +14,21 @@ export function rootReducer(state: State = initialState, action: Action): State 
             return {
                 ...state,
                 count: state.count + 1,
+                doubleCount: state.doubleCount + 2,
             }
         }
         case DECREMENT: {
             return {
                 ...state,
                 count: state.count - 1,
+                doubleCount: state.doubleCount - 2,
             }
         }
         case SET_COUNT: {
             return {
                 ...state,
                 count: action.payload,
+                doubleCount: action.payload,
             }
         }
         default: {

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -1,5 +1,5 @@
-import { Action } from '~/actions/counter'
-import { INCREMENT, DECREMENT } from '~/actions/constants'
+import { Action } from '~/actions'
+import { INCREMENT, DECREMENT, SET_COUNT } from '~/actions/constants'
 
 export const initialState = {
     count: 0,
@@ -19,6 +19,12 @@ export function rootReducer(state: State = initialState, action: Action): State 
             return {
                 ...state,
                 count: state.count - 1,
+            }
+        }
+        case SET_COUNT: {
+            return {
+                ...state,
+                count: action.payload,
             }
         }
         default: {

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -1,0 +1,28 @@
+import { Action } from '~/actions/counter'
+import { INCREMENT, DECREMENT } from '~/actions/constants'
+
+export const initialState = {
+    count: 0,
+}
+
+export type State = typeof initialState
+
+export function rootReducer(state: State = initialState, action: Action): State {
+    switch (action.type) {
+        case INCREMENT: {
+            return {
+                ...state,
+                count: state.count + 1,
+            }
+        }
+        case DECREMENT: {
+            return {
+                ...state,
+                count: state.count - 1,
+            }
+        }
+        default: {
+            return state
+        }
+    }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,7 +14,7 @@ function setState(payload: State): SetStateAction {
         payload,
     }
 }
-const stateReducer = (state = initialState, action: Action | SetStateAction): State => {
+const stateReducer = (state = initialState, action: SetStateAction | never): State => {
     if (action.type === '~/SET_STATE') {
         return action.payload
     }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,7 +1,53 @@
-import { createStore } from 'redux'
-import { initialState, rootReducer } from '~/reducers/rootReducer'
+import { Action } from './actions'
+import { State, initialState } from './reducers/rootReducer'
 export { State } from '~/reducers/rootReducer'
+import { createStore } from 'redux'
 
-const store = createStore(rootReducer, initialState)
+type SetStateAction = {
+    type: '~/SET_STATE'
+    payload: State
+}
+
+function setState(payload: State): SetStateAction {
+    return {
+        type: '~/SET_STATE',
+        payload,
+    }
+}
+const stateReducer = (state = initialState, action: Action | SetStateAction): State => {
+    if (action.type === '~/SET_STATE') {
+        return action.payload
+    }
+    return state
+}
+
+const store = createStore(stateReducer, initialState)
+
+const worker = new Worker('../src/store.worker.ts')
+
+// Preserve the original dispatcher
+const originalDispatch = store.dispatch
+
+// Post all actions directly to the worker
+const workerDispatcher: any = (payload: Action) => {
+    worker.postMessage({
+        type: 'ACTION',
+        payload,
+    })
+    return payload
+}
+
+store.dispatch = workerDispatcher
+
+worker.addEventListener('error', function(event) {
+    console.error('Error in the worker', event)
+})
+
+// Subscribe to worker state updates and override the state with one provided by the worker
+worker.onmessage = (event: MessageEvent) => {
+    if (event.data.type === 'STATE_UPDATE') {
+        originalDispatch(setState(event.data.payload))
+    }
+}
 
 export default store

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,0 +1,7 @@
+import { createStore } from 'redux'
+import { initialState, rootReducer } from '~/reducers/rootReducer'
+export { State } from '~/reducers/rootReducer'
+
+const store = createStore(rootReducer, initialState)
+
+export default store

--- a/src/store.worker.ts
+++ b/src/store.worker.ts
@@ -1,0 +1,35 @@
+import { createStore } from 'redux'
+import { initialState, rootReducer } from '~/reducers/rootReducer'
+import { Action } from './actions'
+import { State } from '~/reducers/rootReducer'
+
+const store = createStore(rootReducer, initialState)
+
+export type ActionMessage = {
+    type: 'ACTION'
+    payload: Action
+}
+
+function isActionMessage(obj: any): obj is ActionMessage {
+    return obj && obj.type === 'ACTION'
+}
+
+export type StateUpdateMessage = {
+    type: 'STATE_UPDATE'
+    payload: State
+}
+onmessage = function(event: MessageEvent) {
+    if (isActionMessage(event.data)) {
+        store.dispatch(event.data.payload)
+    }
+}
+
+store.subscribe(() => {
+    postMessage(
+        {
+            type: 'STATE_UPDATE',
+            payload: store.getState(),
+        },
+        undefined as any,
+    )
+})


### PR DESCRIPTION
Implements a minimal worker-offloaded redux state management by running two stores, one for managing the app-visible state object and a store running in a worker for handling the actual actions